### PR TITLE
Fix: Corregido error de tipo en claves foráneas de usuarios

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE usuarios (
 DROP TABLE IF EXISTS datos_bancarios CASCADE;
 CREATE TABLE datos_bancarios (
     id_dato_bancario SERIAL PRIMARY KEY,
-    id_usuario INT REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
+    id_usuario VARCHAR(9) REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
     IBAN VARCHAR(34),
     num_tarjeta VARCHAR(20),
     fecha_tarjeta DATE,
@@ -34,7 +34,7 @@ CREATE TABLE recursos (
 DROP TABLE IF EXISTS reservas CASCADE;
 CREATE TABLE reservas (
     id_reserva SERIAL PRIMARY KEY,
-    id_usuario INT REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
+    id_usuario VARCHAR(9) REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
     id_recurso INT REFERENCES recursos(id_recurso) ON DELETE CASCADE,
     fecha_inicio TIMESTAMP WITH TIME ZONE NOT NULL,
     fecha_fin TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -74,8 +74,8 @@ CREATE TABLE detalle_factura (
 DROP TABLE IF EXISTS mensajes CASCADE;
 CREATE TABLE mensajes (
     id_mensaje SERIAL PRIMARY KEY,
-    id_emisor INT REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
-    id_receptor INT REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
+    id_emisor VARCHAR(9) REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
+    id_receptor VARCHAR(9) REFERENCES usuarios(id_usuario_dni) ON DELETE CASCADE,
     fecha_mensaje TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     mensaje TEXT NOT NULL
 );
@@ -83,7 +83,7 @@ CREATE TABLE mensajes (
 DROP TABLE IF EXISTS logs CASCADE;
 CREATE TABLE logs (
     id_log SERIAL PRIMARY KEY,
-    id_usuario INT REFERENCES usuarios(id_usuario_dni) ON DELETE SET NULL,
+    id_usuario VARCHAR(9) REFERENCES usuarios(id_usuario_dni) ON DELETE SET NULL,
     fecha_log TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     metodo VARCHAR(10) NOT NULL,
     ip VARCHAR(45) NOT NULL,


### PR DESCRIPTION
Se ha actualizado el tipo de dato de las foreign key de usuario (id_usuario, id_emisor, id_receptor) de INT a VARCHAR(9) en varias tablas (datos_bancarios, reservas, mensajes, logs) para que coincida con el tipo de la primary key en la tabla "usuarios".